### PR TITLE
Correct purchase method to use purchase request

### DIFF
--- a/src/SIMGateway.php
+++ b/src/SIMGateway.php
@@ -45,7 +45,7 @@ class SIMGateway extends AIMGateway
 
     public function purchase(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\AuthorizeNet\Message\SIMAuthorizeRequest', $parameters);
+        return $this->createRequest('\Omnipay\AuthorizeNet\Message\SIMPurchaseRequest', $parameters);
     }
 
     public function completePurchase(array $parameters = array())


### PR DESCRIPTION
Currently the purchase method produces an authorize request, when it should be a purchase.
