### PR TITLE
Fix for unit tests for #13

### DIFF
--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -14,7 +14,90 @@ class AIMResponse extends AbstractResponse
     public function __construct(RequestInterface $request, $data)
     {
         $this->request = $request;
-        $this->data = explode('|,|', substr($data, 1, -1));
+        $temp = explode('|,|', substr($data, 1, -1));
+
+		$response_fields = array(
+			'Response Code',
+			'Response Subcode',
+			'Response Reason Code',
+			'Response Reason Text',
+			'Authorization Code',
+			'AVS Response',
+			'Transaction ID',
+			'Invoice Number',
+			'Description',
+			'Amount',
+			'Method',
+			'Transaction Type',
+			'Customer ID',
+			'First Name',
+			'Last Name',
+			'Company',
+			'Address',
+			'City',
+			'State',
+			'ZIP Code',
+			'Country',
+			'Phone',
+			'Fax',
+			'Email Address',
+			'Ship To First Name',
+			'Ship To Last Name',
+			'Ship To Company',
+			'Ship To Address',
+			'Ship To City',
+			'Ship To State',
+			'Ship To ZIP Code',
+			'Ship To Country',
+			'Tax',
+			'Duty',
+			'Freight',
+			'Tax Exempt',
+			'Purchase Order Number',
+			'MD5 Hash',
+			'Card Code Response',
+			'Cardholder Authentication Verification Response',
+			'Account Number',
+			'Card Type',
+			'Split Tender ID',
+			'Requested Amount',
+			'Balance On Card'
+		);
+
+		$response = array();
+
+		foreach($response_fields as $field)
+		{
+			$response[$field] = array_shift($temp);
+		}
+
+		$response_codes = array(
+			1 => 'Approved',
+			2 => 'Declined',
+			3 => 'Error',
+			4 => 'Held for Review'
+		);
+
+		$avs_response_codes = array(
+			'A' => 'Address (Street) matches, ZIP does not',
+			'B' => 'Address information not provided for AVS check',
+			'E' => 'AVS error',
+			'G' => 'Non-U.S. Card Issuing Bank',
+			'N' => 'No Match on Address (Street) or ZIP',
+			'P' => 'AVS not applicable for this transaction',
+			'R' => 'Retry?System unavailable or timed out',
+			'S' => 'Service not supported by issuer',
+			'U' => 'Address information is unavailable',
+			'W' => 'Nine digit ZIP matches, Address (Street) does not',
+			'X' => 'Address (Street) and nine digit ZIP match',
+			'Y' => 'Address (Street) and five digit ZIP match',
+			'Z' => 'Five digit ZIP matches, Address (Street) does not'
+		);
+
+		$response['Response Code'] = $response_codes[$response['Response Code']];
+		$response['AVS Response'] = $avs_response_codes[$response['AVS Response']];
+
+		$this->data = $response;
 
         if (count($this->data) < 10) {
             throw new InvalidResponseException();
@@ -23,36 +106,36 @@ class AIMResponse extends AbstractResponse
 
     public function isSuccessful()
     {
-        return '1' === $this->getCode();
+        return $this->getCode() == 'Approved';
     }
 
     public function getCode()
     {
-        return $this->data[0];
+        return $this->data['Response Code'];
     }
 
     public function getReasonCode()
     {
-        return $this->data[2];
+        return $this->data['Response Reason Code'];
     }
 
     public function getMessage()
     {
-        return $this->data[3];
+        return $this->data['Response Reason Text'];
     }
 
     public function getAuthorizationCode()
     {
-        return $this->data[4];
+        return $this->data['Authorization Code'];
     }
 
     public function getAVSCode()
     {
-        return $this->data[5];
+        return $this->data['AVS Response'];
     }
 
     public function getTransactionReference()
     {
-        return $this->data[6];
+        return $this->data['Transaction ID'];
     }
 }

--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -14,7 +14,12 @@ class AIMResponse extends AbstractResponse
     public function __construct(RequestInterface $request, $data)
     {
         $this->request = $request;
-        $temp = explode('|,|', substr($data, 1, -1));
+        $rawFields = substr($data, 1, - 1);
+        if ($rawFields !== false) {
+            $temp = explode('|,|', $rawFields);
+        } else {
+            $temp = [];
+        }
 
         $response_fields = array(
             'Response Code',
@@ -67,7 +72,10 @@ class AIMResponse extends AbstractResponse
         $response = array();
 
         foreach ($response_fields as $field) {
-            $response[$field] = array_shift($temp);
+            $responseField    = array_shift($temp);
+            if (!is_null($responseField)) {
+                $response[$field] = $responseField;
+            }
         }
 
         $response_codes = array(
@@ -93,8 +101,17 @@ class AIMResponse extends AbstractResponse
             'Z' => 'Five digit ZIP matches, Address (Street) does not'
         );
 
-        $response['Response Code'] = $response_codes[$response['Response Code']];
-        $response['AVS Response'] = $avs_response_codes[$response['AVS Response']];
+        if (isset($response['Response Code']) && isset($response_codes[$response['Response Code']])) {
+            $response['Response Code'] = $response_codes[$response['Response Code']];
+        } else {
+            $response['Response Code'] = null;
+        }
+        
+        if (isset($response['AVS Response']) && isset($avs_response_codes[$response['AVS Response']])) {
+            $response['AVS Response'] = $avs_response_codes[$response['AVS Response']];
+        } else {
+            $response['AVS Response'] = null;
+        }
 
         $this->data = $response;
 

--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -102,15 +102,15 @@ class AIMResponse extends AbstractResponse
         );
 
         if (isset($response['Response Code']) && isset($response_codes[$response['Response Code']])) {
-            $response['Response Code'] = $response_codes[$response['Response Code']];
+            $response['Response Code Message'] = $response_codes[$response['Response Code']];
         } else {
-            $response['Response Code'] = null;
+            $response['Response Code Message'] = null;
         }
 
         if (isset($response['AVS Response']) && isset($avs_response_codes[$response['AVS Response']])) {
-            $response['AVS Response'] = $avs_response_codes[$response['AVS Response']];
+            $response['AVS Response Message'] = $avs_response_codes[$response['AVS Response']];
         } else {
-            $response['AVS Response'] = null;
+            $response['AVS Response Message'] = null;
         }
 
         $this->data = $response;
@@ -122,12 +122,17 @@ class AIMResponse extends AbstractResponse
 
     public function isSuccessful()
     {
-        return $this->getCode() == 'Approved';
+        return $this->getCodeMessage() == 'Approved';
     }
 
     public function getCode()
     {
         return $this->data['Response Code'];
+    }
+
+    public function getCodeMessage()
+    {
+        return $this->data['Response Code Message'];
     }
 
     public function getReasonCode()
@@ -148,6 +153,11 @@ class AIMResponse extends AbstractResponse
     public function getAVSCode()
     {
         return $this->data['AVS Response'];
+    }
+
+    public function getAVSCodeMessage()
+    {
+        return $this->data['AVS Response Message'];
     }
 
     public function getTransactionReference()

--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -18,7 +18,7 @@ class AIMResponse extends AbstractResponse
         if ($rawFields !== false) {
             $temp = explode('|,|', $rawFields);
         } else {
-            $temp = [];
+            $temp = array();
         }
 
         $response_fields = array(
@@ -72,7 +72,7 @@ class AIMResponse extends AbstractResponse
         $response = array();
 
         foreach ($response_fields as $field) {
-            $responseField    = array_shift($temp);
+            $responseField = array_shift($temp);
             if (!is_null($responseField)) {
                 $response[$field] = $responseField;
             }
@@ -106,7 +106,7 @@ class AIMResponse extends AbstractResponse
         } else {
             $response['Response Code'] = null;
         }
-        
+
         if (isset($response['AVS Response']) && isset($avs_response_codes[$response['AVS Response']])) {
             $response['AVS Response'] = $avs_response_codes[$response['AVS Response']];
         } else {

--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -66,8 +66,7 @@ class AIMResponse extends AbstractResponse
 
         $response = array();
 
-        foreach($response_fields as $field)
-        {
+        foreach ($response_fields as $field) {
             $response[$field] = array_shift($temp);
         }
 

--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -16,88 +16,88 @@ class AIMResponse extends AbstractResponse
         $this->request = $request;
         $temp = explode('|,|', substr($data, 1, -1));
 
-		$response_fields = array(
-			'Response Code',
-			'Response Subcode',
-			'Response Reason Code',
-			'Response Reason Text',
-			'Authorization Code',
-			'AVS Response',
-			'Transaction ID',
-			'Invoice Number',
-			'Description',
-			'Amount',
-			'Method',
-			'Transaction Type',
-			'Customer ID',
-			'First Name',
-			'Last Name',
-			'Company',
-			'Address',
-			'City',
-			'State',
-			'ZIP Code',
-			'Country',
-			'Phone',
-			'Fax',
-			'Email Address',
-			'Ship To First Name',
-			'Ship To Last Name',
-			'Ship To Company',
-			'Ship To Address',
-			'Ship To City',
-			'Ship To State',
-			'Ship To ZIP Code',
-			'Ship To Country',
-			'Tax',
-			'Duty',
-			'Freight',
-			'Tax Exempt',
-			'Purchase Order Number',
-			'MD5 Hash',
-			'Card Code Response',
-			'Cardholder Authentication Verification Response',
-			'Account Number',
-			'Card Type',
-			'Split Tender ID',
-			'Requested Amount',
-			'Balance On Card'
-		);
+        $response_fields = array(
+            'Response Code',
+            'Response Subcode',
+            'Response Reason Code',
+            'Response Reason Text',
+            'Authorization Code',
+            'AVS Response',
+            'Transaction ID',
+            'Invoice Number',
+            'Description',
+            'Amount',
+            'Method',
+            'Transaction Type',
+            'Customer ID',
+            'First Name',
+            'Last Name',
+            'Company',
+            'Address',
+            'City',
+            'State',
+            'ZIP Code',
+            'Country',
+            'Phone',
+            'Fax',
+            'Email Address',
+            'Ship To First Name',
+            'Ship To Last Name',
+            'Ship To Company',
+            'Ship To Address',
+            'Ship To City',
+            'Ship To State',
+            'Ship To ZIP Code',
+            'Ship To Country',
+            'Tax',
+            'Duty',
+            'Freight',
+            'Tax Exempt',
+            'Purchase Order Number',
+            'MD5 Hash',
+            'Card Code Response',
+            'Cardholder Authentication Verification Response',
+            'Account Number',
+            'Card Type',
+            'Split Tender ID',
+            'Requested Amount',
+            'Balance On Card'
+        );
 
-		$response = array();
+        $response = array();
 
-		foreach($response_fields as $field)
-		{
-			$response[$field] = array_shift($temp);
-		}
+        foreach($response_fields as $field)
+        {
+            $response[$field] = array_shift($temp);
+        }
 
-		$response_codes = array(
-			1 => 'Approved',
-			2 => 'Declined',
-			3 => 'Error',
-			4 => 'Held for Review'
-		);
+        $response_codes = array(
+            1 => 'Approved',
+            2 => 'Declined',
+            3 => 'Error',
+            4 => 'Held for Review'
+        );
 
-		$avs_response_codes = array(
-			'A' => 'Address (Street) matches, ZIP does not',
-			'B' => 'Address information not provided for AVS check',
-			'E' => 'AVS error',
-			'G' => 'Non-U.S. Card Issuing Bank',
-			'N' => 'No Match on Address (Street) or ZIP',
-			'P' => 'AVS not applicable for this transaction',
-			'R' => 'Retry?System unavailable or timed out',
-			'S' => 'Service not supported by issuer',
-			'U' => 'Address information is unavailable',
-			'W' => 'Nine digit ZIP matches, Address (Street) does not',
-			'X' => 'Address (Street) and nine digit ZIP match',
-			'Y' => 'Address (Street) and five digit ZIP match',
-			'Z' => 'Five digit ZIP matches, Address (Street) does not'
-		);
+        $avs_response_codes = array(
+            'A' => 'Address (Street) matches, ZIP does not',
+            'B' => 'Address information not provided for AVS check',
+            'E' => 'AVS error',
+            'G' => 'Non-U.S. Card Issuing Bank',
+            'N' => 'No Match on Address (Street) or ZIP',
+            'P' => 'AVS not applicable for this transaction',
+            'R' => 'Retry?System unavailable or timed out',
+            'S' => 'Service not supported by issuer',
+            'U' => 'Address information is unavailable',
+            'W' => 'Nine digit ZIP matches, Address (Street) does not',
+            'X' => 'Address (Street) and nine digit ZIP match',
+            'Y' => 'Address (Street) and five digit ZIP match',
+            'Z' => 'Five digit ZIP matches, Address (Street) does not'
+        );
 
-		$response['Response Code'] = $response_codes[$response['Response Code']];
-		$response['AVS Response'] = $avs_response_codes[$response['AVS Response']];
+        $response['Response Code'] = $response_codes[$response['Response Code']];
+        $response['AVS Response'] = $avs_response_codes[$response['AVS Response']];
 
-		$this->data = $response;
+        $this->data = $response;
 
         if (count($this->data) < 10) {
             throw new InvalidResponseException();

--- a/tests/Message/AIMResponseTest.php
+++ b/tests/Message/AIMResponseTest.php
@@ -7,7 +7,7 @@ use Omnipay\Tests\TestCase;
 class AIMResponseTest extends TestCase
 {
     /**
-     * @expectedException Omnipay\Common\Exception\InvalidResponseException
+     * @expectedException \Omnipay\Common\Exception\InvalidResponseException
      */
     public function testConstructEmpty()
     {

--- a/tests/Message/AIMResponseTest.php
+++ b/tests/Message/AIMResponseTest.php
@@ -22,10 +22,10 @@ class AIMResponseTest extends TestCase
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('2184493132', $response->getTransactionReference());
         $this->assertSame('This transaction has been approved.', $response->getMessage());
-        $this->assertSame('1', $response->getCode());
+        $this->assertSame('Approved', $response->getCode());
         $this->assertSame('1', $response->getReasonCode());
         $this->assertSame('GA4OQP', $response->getAuthorizationCode());
-        $this->assertSame('Y', $response->getAVSCode());
+        $this->assertSame('Address (Street) and five digit ZIP match', $response->getAVSCode());
     }
 
     public function testAuthorizeFailure()
@@ -36,10 +36,10 @@ class AIMResponseTest extends TestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertSame('0', $response->getTransactionReference());
         $this->assertSame('A valid amount is required.', $response->getMessage());
-        $this->assertSame('3', $response->getCode());
+        $this->assertSame('Error', $response->getCode());
         $this->assertSame('5', $response->getReasonCode());
         $this->assertSame('', $response->getAuthorizationCode());
-        $this->assertSame('P', $response->getAVSCode());
+        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCode());
     }
 
     public function testCaptureSuccess()
@@ -50,10 +50,10 @@ class AIMResponseTest extends TestCase
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('2184494531', $response->getTransactionReference());
         $this->assertSame('This transaction has been approved.', $response->getMessage());
-        $this->assertSame('1', $response->getCode());
+        $this->assertSame('Approved', $response->getCode());
         $this->assertSame('1', $response->getReasonCode());
         $this->assertSame('F51OYG', $response->getAuthorizationCode());
-        $this->assertSame('P', $response->getAVSCode());
+        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCode());
     }
 
     public function testCaptureFailure()
@@ -64,10 +64,10 @@ class AIMResponseTest extends TestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertSame('0', $response->getTransactionReference());
         $this->assertSame('The transaction cannot be found.', $response->getMessage());
-        $this->assertSame('3', $response->getCode());
+        $this->assertSame('Error', $response->getCode());
         $this->assertSame('16', $response->getReasonCode());
         $this->assertSame('', $response->getAuthorizationCode());
-        $this->assertSame('P', $response->getAVSCode());
+        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCode());
     }
 
     public function testPurchaseSuccess()
@@ -78,10 +78,10 @@ class AIMResponseTest extends TestCase
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('2184492509', $response->getTransactionReference());
         $this->assertSame('This transaction has been approved.', $response->getMessage());
-        $this->assertSame('1', $response->getCode());
+        $this->assertSame('Approved', $response->getCode());
         $this->assertSame('1', $response->getReasonCode());
         $this->assertSame('JE6JM1', $response->getAuthorizationCode());
-        $this->assertSame('Y', $response->getAVSCode());
+        $this->assertSame('Address (Street) and five digit ZIP match', $response->getAVSCode());
     }
 
     public function testPurchaseFailure()
@@ -92,9 +92,9 @@ class AIMResponseTest extends TestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertSame('0', $response->getTransactionReference());
         $this->assertSame('A valid amount is required.', $response->getMessage());
-        $this->assertSame('3', $response->getCode());
+        $this->assertSame('Error', $response->getCode());
         $this->assertSame('5', $response->getReasonCode());
         $this->assertSame('', $response->getAuthorizationCode());
-        $this->assertSame('P', $response->getAVSCode());
+        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCode());
     }
 }

--- a/tests/Message/AIMResponseTest.php
+++ b/tests/Message/AIMResponseTest.php
@@ -107,9 +107,9 @@ class AIMResponseTest extends TestCase
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('2184492509', $response->getTransactionReference());
         $this->assertSame('This transaction has been approved.', $response->getMessage());
-        $this->assertSame('1', $response->getCode());
+        $this->assertSame('Approved', $response->getCode());
         $this->assertSame('1', $response->getReasonCode());
-        $this->assertSame('P', $response->getAVSCode());
+        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCode());
     }
 
     public function testRefundFailure()
@@ -120,9 +120,9 @@ class AIMResponseTest extends TestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertSame('0', $response->getTransactionReference());
         $this->assertSame('The credit card number is invalid.', $response->getMessage());
-        $this->assertSame('3', $response->getCode());
+        $this->assertSame('Error', $response->getCode());
         $this->assertSame('6', $response->getReasonCode());
         $this->assertSame('', $response->getAuthorizationCode());
-        $this->assertSame('P', $response->getAVSCode());
+        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCode());
     }
 }

--- a/tests/Message/AIMResponseTest.php
+++ b/tests/Message/AIMResponseTest.php
@@ -22,10 +22,12 @@ class AIMResponseTest extends TestCase
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('2184493132', $response->getTransactionReference());
         $this->assertSame('This transaction has been approved.', $response->getMessage());
-        $this->assertSame('Approved', $response->getCode());
+        $this->assertSame('1', $response->getCode());
+        $this->assertSame('Approved', $response->getCodeMessage());
         $this->assertSame('1', $response->getReasonCode());
         $this->assertSame('GA4OQP', $response->getAuthorizationCode());
-        $this->assertSame('Address (Street) and five digit ZIP match', $response->getAVSCode());
+        $this->assertSame('Y', $response->getAVSCode());
+        $this->assertSame('Address (Street) and five digit ZIP match', $response->getAVSCodeMessage());
     }
 
     public function testAuthorizeFailure()
@@ -36,10 +38,12 @@ class AIMResponseTest extends TestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertSame('0', $response->getTransactionReference());
         $this->assertSame('A valid amount is required.', $response->getMessage());
-        $this->assertSame('Error', $response->getCode());
+        $this->assertSame('3', $response->getCode());
+        $this->assertSame('Error', $response->getCodeMessage());
         $this->assertSame('5', $response->getReasonCode());
         $this->assertSame('', $response->getAuthorizationCode());
-        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCode());
+        $this->assertSame('P', $response->getAVSCode());
+        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCodeMessage());
     }
 
     public function testCaptureSuccess()
@@ -50,10 +54,12 @@ class AIMResponseTest extends TestCase
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('2184494531', $response->getTransactionReference());
         $this->assertSame('This transaction has been approved.', $response->getMessage());
-        $this->assertSame('Approved', $response->getCode());
+        $this->assertSame('1', $response->getCode());
+        $this->assertSame('Approved', $response->getCodeMessage());
         $this->assertSame('1', $response->getReasonCode());
         $this->assertSame('F51OYG', $response->getAuthorizationCode());
-        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCode());
+        $this->assertSame('P', $response->getAVSCode());
+        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCodeMessage());
     }
 
     public function testCaptureFailure()
@@ -64,10 +70,12 @@ class AIMResponseTest extends TestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertSame('0', $response->getTransactionReference());
         $this->assertSame('The transaction cannot be found.', $response->getMessage());
-        $this->assertSame('Error', $response->getCode());
+        $this->assertSame('3', $response->getCode());
+        $this->assertSame('Error', $response->getCodeMessage());
         $this->assertSame('16', $response->getReasonCode());
         $this->assertSame('', $response->getAuthorizationCode());
-        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCode());
+        $this->assertSame('P', $response->getAVSCode());
+        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCodeMessage());
     }
 
     public function testPurchaseSuccess()
@@ -78,10 +86,12 @@ class AIMResponseTest extends TestCase
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('2184492509', $response->getTransactionReference());
         $this->assertSame('This transaction has been approved.', $response->getMessage());
-        $this->assertSame('Approved', $response->getCode());
+        $this->assertSame('1', $response->getCode());
+        $this->assertSame('Approved', $response->getCodeMessage());
         $this->assertSame('1', $response->getReasonCode());
         $this->assertSame('JE6JM1', $response->getAuthorizationCode());
-        $this->assertSame('Address (Street) and five digit ZIP match', $response->getAVSCode());
+        $this->assertSame('Y', $response->getAVSCode());
+        $this->assertSame('Address (Street) and five digit ZIP match', $response->getAVSCodeMessage());
     }
 
     public function testPurchaseFailure()
@@ -92,10 +102,12 @@ class AIMResponseTest extends TestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertSame('0', $response->getTransactionReference());
         $this->assertSame('A valid amount is required.', $response->getMessage());
-        $this->assertSame('Error', $response->getCode());
+        $this->assertSame('3', $response->getCode());
+        $this->assertSame('Error', $response->getCodeMessage());
         $this->assertSame('5', $response->getReasonCode());
         $this->assertSame('', $response->getAuthorizationCode());
-        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCode());
+        $this->assertSame('P', $response->getAVSCode());
+        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCodeMessage());
     }
 
     public function testRefundSuccess()
@@ -107,9 +119,11 @@ class AIMResponseTest extends TestCase
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('2184492509', $response->getTransactionReference());
         $this->assertSame('This transaction has been approved.', $response->getMessage());
-        $this->assertSame('Approved', $response->getCode());
+        $this->assertSame('1', $response->getCode());
+        $this->assertSame('Approved', $response->getCodeMessage());
         $this->assertSame('1', $response->getReasonCode());
-        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCode());
+        $this->assertSame('P', $response->getAVSCode());
+        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCodeMessage());
     }
 
     public function testRefundFailure()
@@ -120,9 +134,11 @@ class AIMResponseTest extends TestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertSame('0', $response->getTransactionReference());
         $this->assertSame('The credit card number is invalid.', $response->getMessage());
-        $this->assertSame('Error', $response->getCode());
+        $this->assertSame('3', $response->getCode());
+        $this->assertSame('Error', $response->getCodeMessage());
         $this->assertSame('6', $response->getReasonCode());
         $this->assertSame('', $response->getAuthorizationCode());
-        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCode());
+        $this->assertSame('P', $response->getAVSCode());
+        $this->assertSame('AVS not applicable for this transaction', $response->getAVSCodeMessage());
     }
 }


### PR DESCRIPTION
This PR contains a couple of potential fixes for PR #13:

The logic around splitting up the body was previously "working" but I think due to coincidence. Stripping off the leading and trailing pipe in the API response will result in a false if the body is blank or too small, substr will return false. I updated to explicitly test for this. If it was too small then the new $temp becomes a blank array.

The previous logic just exploded the body into $this->data, but with the new field list the logic has changed. Continually calling array_shift on a variable that starts as a blank array will result in nulls. Previously the first call ended up with an empty string due to exploding on false resulting in an array containing a single blank string.

Since we're dealing with (the happy path) strings, I added a bit to ignore nulls and not add the fields if the value is null. This part can likely be improved.

The final two issues were from notices popping up with the blank body test but expecting there would be values in the response for Response Code and AVS Response. I wrapped these in "isset" calls and set them to null if they don't have values. 

I'm completely unfamilar with authorize.net other than what I learned from glancing at a couple of the tests so please make sure I haven't broken any logic. 

TL;DR
This should fix the test/build for PR #13. @acicali