### PR TITLE
Include omnipay_transaction_id in hidden fields for the DPM form.

### DIFF
--- a/src/Message/DPMResponse.php
+++ b/src/Message/DPMResponse.php
@@ -59,6 +59,9 @@ class DPMResponse extends AbstractResponse implements RedirectResponseInterface
         'x_email_customer',
 
         'x_delim_data',
+
+        // Custom omnipay field.
+        'omnipay_transaction_id',
     );
 
     /**


### PR DESCRIPTION
This was missing from a previous PR. Without it, the transaction ID does not get sent to OmniPay in the DPM form, and so is not accessible in the notify handler using `$request->getTransactionId()` - assuming `DPMResponse::getRedirectData()` is used to get all the hidden fields for use on the DPM form.

The current workaround is to make the field hidden manually:

    $gateway = Omnipay::create('AuthorizeNet_DPM');
    $request = $gateway->purchase($details);
    $response = $request->send();
    $response->hideField('omnipay_transaction_id');

then all the data returned by this method should be put into the DPM form as hidden fields.

    $response->getRedirectData();

In addition, the transaction ID is still being put into the `invoiceNumber` field - but don't rely on this long term - it ain't an invoice number.

More details and some tests to come. Just throwing this PR in as a placeholder, to come back to possibly in a few days.