### PR TITLE
[AIMRefund] Pass credit card expiration date only when one is present

### DIFF
--- a/src/Message/AIMRefundRequest.php
+++ b/src/Message/AIMRefundRequest.php
@@ -17,7 +17,9 @@ class AIMRefundRequest extends AbstractRequest
 
         $data['x_trans_id'] = $this->getTransactionReference();
         $data['x_card_num'] = $this->getCard()->getNumber();
-        $data['x_exp_date'] = $this->getCard()->getExpiryDate('my');
+        if (!empty($this->getCard()->getExpiryMonth())) {
+            $data['x_exp_date'] = $this->getCard()->getExpiryDate('my');
+        }
         $data['x_amount'] = $this->getAmount();
 
         return $data;

--- a/src/Message/AIMRefundRequest.php
+++ b/src/Message/AIMRefundRequest.php
@@ -17,9 +17,12 @@ class AIMRefundRequest extends AbstractRequest
 
         $data['x_trans_id'] = $this->getTransactionReference();
         $data['x_card_num'] = $this->getCard()->getNumber();
-        if (!empty($this->getCard()->getExpiryMonth())) {
+
+        $expiryMonth = $this->getCard()->getExpiryMonth();
+        if (!empty($expiryMonth)) {
             $data['x_exp_date'] = $this->getCard()->getExpiryDate('my');
         }
+
         $data['x_amount'] = $this->getAmount();
 
         return $data;

--- a/tests/Message/AIMRefundRequestTest.php
+++ b/tests/Message/AIMRefundRequestTest.php
@@ -29,5 +29,24 @@ class AIMRefundRequestTest extends TestCase
         $this->assertSame('60O2UZ', $data['x_trans_id']);
         $this->assertSame($card['number'], $data['x_card_num']);
         $this->assertSame('12.00', $data['x_amount']);
+
+        $this->assertArrayHasKey('x_exp_date', $data);
+    }
+
+    public function testRefundWithSimplifiedCard()
+    {
+        $simplifiedCard = array(
+            'firstName' => 'Example',
+            'lastName' => 'User',
+            'number' => '1111',
+        );
+
+        $this->request->setCard($simplifiedCard);
+
+        $data = $this->request->getData();
+
+        $this->assertSame($simplifiedCard['number'], $data['x_card_num']);
+
+        $this->assertArrayNotHasKey('x_exp_date', $data);
     }
 }


### PR DESCRIPTION
Authorize.Net does not require the expiration date when performing refunds. When no expiration is passed in and a refund request is made, the response comes back with an error saying the card has expired. 

This check makes it so the expiration date is only sent when a valid expiry date is passed in to the request parameters. 

http://www.authorize.net/content/dam/authorize/documents/AIM_guide.pdf
> At least the last four digits of the credit card number (x_card_num) used for the
original, successfully settled transaction are submitted. An expiration date is not
required.