### PR TITLE
Set phoneNumber attribute for billTo (but not shipTo) on AIM requests.

### DIFF
--- a/src/Message/AIMAbstractRequest.php
+++ b/src/Message/AIMAbstractRequest.php
@@ -221,6 +221,7 @@ abstract class AIMAbstractRequest extends AbstractRequest
             $req->billTo->state = $card->getBillingState();
             $req->billTo->zip = $card->getBillingPostcode();
             $req->billTo->country = $card->getBillingCountry();
+            $req->billTo->phoneNumber = $card->getBillingPhone();
 
             $req->shipTo->firstName = $card->getShippingFirstName();
             $req->shipTo->lastName = $card->getShippingLastName();
@@ -230,6 +231,7 @@ abstract class AIMAbstractRequest extends AbstractRequest
             $req->shipTo->state = $card->getShippingState();
             $req->shipTo->zip = $card->getShippingPostcode();
             $req->shipTo->country = $card->getShippingCountry();
+            $req->shipTo->phoneNumber = $card->getShippingPhone();
         }
 
         return $data;

--- a/src/Message/AIMAbstractRequest.php
+++ b/src/Message/AIMAbstractRequest.php
@@ -231,7 +231,6 @@ abstract class AIMAbstractRequest extends AbstractRequest
             $req->shipTo->state = $card->getShippingState();
             $req->shipTo->zip = $card->getShippingPostcode();
             $req->shipTo->country = $card->getShippingCountry();
-            $req->shipTo->phoneNumber = $card->getShippingPhone();
         }
 
         return $data;


### PR DESCRIPTION
The billTo->phoneNumber attribute for AIM requests is required in some situations. Without it an error is returned that states "Phone is required"

This PR supports setting these attributes via the standard omnipay method calls.