### PR TITLE
Issue40 - fetching messages from the correct place

### DIFF
--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -48,7 +48,13 @@ class AIMResponse extends AbstractResponse
      */
     public function getResultCode()
     {
-        return intval((string)$this->data->transactionResponse[0]->responseCode);
+        if (isset($this->data->transactionResponse[0]->responseCode)) {
+            return intval((string)$this->data->transactionResponse[0]->responseCode);
+        } else {
+            // If there is no transactionResponse element present then there was an error with authentication.
+            // Hence we can return 3 for Error
+            return 3;
+        }
     }
 
     /**

--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -59,7 +59,7 @@ class AIMResponse extends AbstractResponse
 
     /**
      * A more detailed version of the Result/Response code.
-     * CHECKME: the message and error codes are NOT numeric, so the intval() provably needs to be removed.
+     * CHECKME: the message and error codes are NOT numeric, so the intval() probably needs to be removed.
      *
      * @return int|null
      */
@@ -81,6 +81,14 @@ class AIMResponse extends AbstractResponse
         }
 
         return $code;
+    }
+
+    /**
+     * @inherit
+     */
+    public function getCode()
+    {
+        return $this->getReasonCode();
     }
 
     /**

--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -53,6 +53,7 @@ class AIMResponse extends AbstractResponse
 
     /**
      * A more detailed version of the Result/Response code.
+     * CHECKME: the message and error codes are NOT numeric, so the intval() provably needs to be removed.
      *
      * @return int|null
      */
@@ -67,6 +68,10 @@ class AIMResponse extends AbstractResponse
         } elseif (isset($this->data->transactionResponse[0]->errors)) {
             // In case of an unsuccessful transaction, an "errors" element is present
             $code = intval((string)$this->data->transactionResponse[0]->errors[0]->error[0]->errorCode);
+
+        } elseif (isset($this->data->messages[0]->message)) {
+            // In case of an unsuccessful authentication, the error will be in a different structure.
+            $code = (string)$this->data->messages[0]->message->code;
         }
 
         return $code;
@@ -88,6 +93,10 @@ class AIMResponse extends AbstractResponse
         } elseif (isset($this->data->transactionResponse[0]->errors)) {
             // In case of an unsuccessful transaction, an "errors" element is present
             $message = (string)$this->data->transactionResponse[0]->errors[0]->error[0]->errorText;
+
+        } elseif (isset($this->data->messages[0]->message)) {
+            // In case of invalid authentication or incorrectly structured request message.
+            $message = (string)$this->data->messages[0]->message->text;
         }
 
         return $message;

--- a/tests/Message/AIMAbstractRequestTest.php
+++ b/tests/Message/AIMAbstractRequestTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Message;
-
 
 use Omnipay\AuthorizeNet\Message\AIMAbstractRequest;
 
@@ -16,8 +14,8 @@ class AIMAbstractRequestTest extends \PHPUnit_Framework_TestCase
         $this->request = $this->getMockForAbstractClass(
             '\Omnipay\AuthorizeNet\Message\AIMAbstractRequest',
             array(
-                $this->getMock('\Guzzle\Http\ClientInterface'),
-                $this->getMock('\Symfony\Component\HttpFoundation\Request')
+                $this->createMock('\Guzzle\Http\ClientInterface'),
+                $this->createMock('\Symfony\Component\HttpFoundation\Request')
             )
         );
     }

--- a/tests/Message/AIMAbstractRequestTest.php
+++ b/tests/Message/AIMAbstractRequestTest.php
@@ -14,8 +14,8 @@ class AIMAbstractRequestTest extends \PHPUnit_Framework_TestCase
         $this->request = $this->getMockForAbstractClass(
             '\Omnipay\AuthorizeNet\Message\AIMAbstractRequest',
             array(
-                $this->createMock('\Guzzle\Http\ClientInterface'),
-                $this->createMock('\Symfony\Component\HttpFoundation\Request')
+                $this->getMock('\Guzzle\Http\ClientInterface'),
+                $this->getMock('\Symfony\Component\HttpFoundation\Request')
             )
         );
     }

--- a/tests/Message/AIMAuthorizeRequestTest.php
+++ b/tests/Message/AIMAuthorizeRequestTest.php
@@ -34,11 +34,13 @@ class AIMAuthorizeRequestTest extends TestCase
         // Issue #38 Make sure the transactionRequest properties are correctly ordered.
         // This feels messy, but works.
         $transactionRequestProperties = array_keys(get_object_vars($data->transactionRequest));
+
         // The names of the properies of the $data->transactionRequest object, in the order in
         // which they must be defined for Authorize.Net to accept the transaction.
         $keys = array(
             "transactionType",
             "amount",
+            //"description",
             "payment",
             "customer",
             "billTo",

--- a/tests/Message/AIMAuthorizeRequestTest.php
+++ b/tests/Message/AIMAuthorizeRequestTest.php
@@ -17,6 +17,7 @@ class AIMAuthorizeRequestTest extends TestCase
                 'clientIp' => '10.0.0.1',
                 'amount' => '12.00',
                 'customerId' => 'cust-id',
+                //'description' => 'Description',
                 'card' => $this->getValidCard(),
                 'duplicateWindow' => 0
             )


### PR DESCRIPTION
Error messages when authentication fails will be in a different place in the received XML structure to messages returned with failed transactions. This fix looks in the correct place as a fallback.

This PR does need some tests before merging.
