### PR TITLE
Use new Akamai SureRoute endpoint for AIM and CIM

### DIFF
--- a/src/AIMGateway.php
+++ b/src/AIMGateway.php
@@ -26,7 +26,7 @@ class AIMGateway extends AbstractGateway
             'transactionKey'    => '',
             'testMode'          => false,
             'developerMode'     => false,
-            'liveEndpoint'      => 'https://api.authorize.net/xml/v1/request.api',
+            'liveEndpoint'      => 'https://api2.authorize.net/xml/v1/request.api',
             'developerEndpoint' => 'https://apitest.authorize.net/xml/v1/request.api',
         );
     }

--- a/tests/AIMGatewayTest.php
+++ b/tests/AIMGatewayTest.php
@@ -43,7 +43,7 @@ class AIMGatewayTest extends GatewayTestCase
     public function testLiveEndpoint()
     {
         $this->assertEquals(
-            'https://api.authorize.net/xml/v1/request.api',
+            'https://api2.authorize.net/xml/v1/request.api',
             $this->gateway->getLiveEndpoint()
         );
     }

--- a/tests/CIMGatewayTest.php
+++ b/tests/CIMGatewayTest.php
@@ -49,7 +49,7 @@ class CIMGatewayTest extends GatewayTestCase
     public function testLiveEndpoint()
     {
         $this->assertEquals(
-            'https://api.authorize.net/xml/v1/request.api',
+            'https://api2.authorize.net/xml/v1/request.api',
             $this->gateway->getLiveEndpoint()
         );
     }


### PR DESCRIPTION
Previously only SIM and DPM Gateways were utilizing the new Akamai SureRoute endpoints. Authorize.net has stopped forcing the migration, but who knows how long that will last. This should resolve #42.

`CIMGatewayIntegrationTest` does not pass without errors for me (it incorrectly allows for a duplicate profile to be created), but the code in `master` fails with the same error so it shouldn't be anything I've added. Curious to see if it fails for Travis CI, too.
