### PR TITLE
Getting malformed guzzle URL

### DIFF
--- a/src/Message/CIMCreateCardRequest.php
+++ b/src/Message/CIMCreateCardRequest.php
@@ -250,7 +250,7 @@ class CIMCreateCardRequest extends CIMAbstractRequest
     public function makeCreatePaymentProfileRequest($parameters)
     {
         $obj = new CIMCreatePaymentProfileRequest($this->httpClient, $this->httpRequest);
-        $obj->initialize($parameters);
+        $obj->initialize(array_replace($this->getParameters(), $parameters));
         return $obj->send();
     }
 


### PR DESCRIPTION
The makeCreatePaymentProfileRequest was not init params the same as
everything else. As a result guzzle was throwing a malformed url error.