### PR TITLE
Issue40

### DIFF
--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -46,7 +46,7 @@ class AIMResponse extends AbstractResponse
      * A result of 0 is returned if there is no transaction response returned, e.g. a validation error in
      * some data, or invalid login credentials.
      *
-     * @return int 1 = Approved, 2 = Declined, 3 = Error, 4 = Held for Review, 0 = Validation Error
+     * @return int 1 = Approved, 2 = Declined, 3 = Error, 4 = Held for Review
      */
     public function getResultCode()
     {
@@ -55,9 +55,8 @@ class AIMResponse extends AbstractResponse
             return intval((string)$this->data->transactionResponse[0]->responseCode);
         }
 
-        // No transaction response, so no transaction was attempted, hence no
-        // transaction response code that we can return.
-        return 0;
+        // No transaction response, so return 3 aka "error".
+        return 3;
     }
 
     /**

--- a/tests/Message/AIMResponseTest.php
+++ b/tests/Message/AIMResponseTest.php
@@ -50,6 +50,20 @@ class AIMResponseTest extends TestCase
         $this->assertSame('P', $response->getAVSCode());
     }
 
+    public function testAuthorizeInvalid()
+    {
+        $httpResponse = $this->getMockHttpResponse('AIMAuthorizeInvalid.txt');
+        $response = new AIMResponse($this->getMockRequest(), $httpResponse->getBody());
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertSame('', $response->getTransactionReference());
+        $this->assertSame('User authentication failed due to invalid authentication values.', $response->getMessage());
+        $this->assertSame(3, $response->getResultCode());
+        $this->assertSame('E00007', $response->getReasonCode());
+        $this->assertSame('', $response->getAuthorizationCode());
+        $this->assertSame('', $response->getAVSCode());
+    }
+
     public function testCaptureSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('AIMCaptureSuccess.txt');

--- a/tests/Mock/AIMAuthorizeInvalid.txt
+++ b/tests/Mock/AIMAuthorizeInvalid.txt
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Date: Sat, 02 Aug 2014 05:20:38 GMT
+Server: Microsoft-IIS/6.0
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: GET, POST, OPTIONS
+Access-Control-Allow-Headers: x-requested-with, cache-control, content-type, origin, method
+X-Powered-By: ASP.NET
+X-AspNet-Version: 2.0.50727
+Cache-Control: private
+Content-Type: text/xml; charset=utf-8
+Content-Length: 844
+
+<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><refId>123456</refId><messages><resultCode>Error</resultCode><message><code>E00007</code><text>User authentication failed due to invalid authentication values.</text></message></messages></createTransactionResponse>


### PR DESCRIPTION
Get result code from the transaction, if available, otherwise default to '3' (error).

Get the reason code and message from the transaction (first on the 'messages' or 'errors' list) or from the top-level response if there is no transaction returned.