### PR TITLE
OpaqueData on CIM CreatePaymentProfile/UpdatePaymentProfile

### DIFF
--- a/src/CIMGateway.php
+++ b/src/CIMGateway.php
@@ -46,6 +46,11 @@ class CIMGateway extends AIMGateway
         return $this->createRequest('\Omnipay\AuthorizeNet\Message\CIMCreateCardRequest', $parameters);
     }
 
+    public function updateCard(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\AuthorizeNet\Message\CIMUpdatePaymentProfileRequest', $parameters);
+    }
+
     public function getPaymentProfile(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\AuthorizeNet\Message\CIMGetPaymentProfileRequest', $parameters);

--- a/src/Message/CIMCreateCardRequest.php
+++ b/src/Message/CIMCreateCardRequest.php
@@ -214,8 +214,12 @@ class CIMCreateCardRequest extends CIMAbstractRequest
         $createPaymentProfileResponse = $this->makeCreatePaymentProfileRequest($parameters);
         if ($createPaymentProfileResponse->isSuccessful()) {
             $parameters['customerPaymentProfileId'] = $createPaymentProfileResponse->getCustomerPaymentProfileId();
-        } elseif ($this->getForceCardUpdate() !== true) {
+        } elseif (
+            $this->getForceCardUpdate() !== true ||
+            ($this->getOpaqueDataDescriptor() && $this->getOpaqueDataValue())
+        ) {
             // force card update flag turned off. No need to further process.
+            // also if opaque data is being used we are not able to update existing payment profiles
             return $createCardResponse;
         }
 

--- a/src/Message/CIMCreateCardRequest.php
+++ b/src/Message/CIMCreateCardRequest.php
@@ -214,8 +214,7 @@ class CIMCreateCardRequest extends CIMAbstractRequest
         $createPaymentProfileResponse = $this->makeCreatePaymentProfileRequest($parameters);
         if ($createPaymentProfileResponse->isSuccessful()) {
             $parameters['customerPaymentProfileId'] = $createPaymentProfileResponse->getCustomerPaymentProfileId();
-        } elseif (
-            $this->getForceCardUpdate() !== true ||
+        } elseif ($this->getForceCardUpdate() !== true ||
             ($this->getOpaqueDataDescriptor() && $this->getOpaqueDataValue())
         ) {
             // force card update flag turned off. No need to further process.

--- a/src/Message/CIMCreatePaymentProfileRequest.php
+++ b/src/Message/CIMCreatePaymentProfileRequest.php
@@ -14,11 +14,7 @@ class CIMCreatePaymentProfileRequest extends CIMCreateCardRequest
     public function getData()
     {
         $this->validate('card', 'customerProfileId');
-
-        /** @var CreditCard $card */
-        $card = $this->getCard();
-        $card->validate();
-
+        $this->cardValidate();
         $data = $this->getBaseData();
         $data->customerProfileId = $this->getCustomerProfileId();
         $this->addPaymentProfileData($data);

--- a/src/Message/CIMUpdatePaymentProfileRequest.php
+++ b/src/Message/CIMUpdatePaymentProfileRequest.php
@@ -15,9 +15,7 @@ class CIMUpdatePaymentProfileRequest extends CIMCreatePaymentProfileRequest
     {
         $this->validate('card', 'customerProfileId', 'customerPaymentProfileId');
 
-        /** @var CreditCard $card */
-        $card = $this->getCard();
-        $card->validate();
+        $this->cardValidate();
 
         $data = $this->getBaseData();
         $data->customerProfileId = $this->getCustomerProfileId();

--- a/tests/CIMGatewayTest.php
+++ b/tests/CIMGatewayTest.php
@@ -130,6 +130,21 @@ class CIMGatewayTest extends GatewayTestCase
         $this->assertSame('Successful.', $response->getMessage());
     }
 
+    public function testShouldCreateCardFromOpaqueDataIfDuplicateCustomerProfileExists()
+    {
+        $this->setMockHttpResponse(array('CIMCreateCardFailureWithDuplicate.txt', 'CIMCreatePaymentProfileSuccess.txt',
+            'CIMGetProfileSuccess.txt', 'CIMGetPaymentProfileSuccess.txt'));
+
+        $response = $this->gateway->createCard($this->createCardFromOpaqueDataOptions)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame(
+            '{"customerProfileId":"28775801","customerPaymentProfileId":"26485433"}',
+            $response->getCardReference()
+        );
+        $this->assertSame('Successful.', $response->getMessage());
+    }
+
     public function testShouldUpdateExistingPaymentProfileIfDuplicateExistsAndForceCardUpdateIsSet()
     {
         // Duplicate **payment** profile
@@ -144,6 +159,17 @@ class CIMGatewayTest extends GatewayTestCase
             $response->getCardReference()
         );
         $this->assertSame('Successful.', $response->getMessage());
+    }
+
+    public function testDoesntUpdateExistingPaymentProfileFromOpaqueData()
+    {
+        // Duplicate **payment** profile
+        $this->setMockHttpResponse(array('CIMCreateCardFailureWithDuplicate.txt', 'CIMCreatePaymentProfileFailure.txt',
+            'CIMGetProfileSuccess.txt', 'CIMUpdatePaymentProfileSuccess.txt', 'CIMGetPaymentProfileSuccess.txt'));
+
+        $response = $this->gateway->createCard($this->createCardFromOpaqueDataOptions)->send();
+
+        $this->assertFalse($response->isSuccessful());
     }
 
     public function testShouldUpdateExistingPaymentProfileIfDuplicateExistsAndMaxPaymentProfileLimitIsMet()

--- a/tests/Message/CIMCreateCardResponseTest.php
+++ b/tests/Message/CIMCreateCardResponseTest.php
@@ -43,18 +43,4 @@ class CIMCreateCardResponseTest extends TestCase
 
         $this->assertNull($response->getCardReference());
     }
-
-    public function testCreateCardSuccessFromOpaqueData()
-    {
-        $httpResponse = $this->getMockHttpResponse('CIMCreateCardSuccess.txt');
-        $response = new CIMCreateCardResponse($this->getMockRequest(), $httpResponse->getBody());
-
-        $this->assertTrue($response->isSuccessful());
-        $this->assertEquals('I00001', $response->getReasonCode());
-        $this->assertEquals("1", $response->getResultCode());
-        $this->assertEquals("Successful.", $response->getMessage());
-
-        $this->assertEquals('28972084', $response->getCustomerProfileId());
-        $this->assertEquals('26317840', $response->getCustomerPaymentProfileId());
-    }
 }

--- a/tests/Message/CIMCreatePaymentProfileRequestTest.php
+++ b/tests/Message/CIMCreatePaymentProfileRequestTest.php
@@ -31,4 +31,25 @@ class CIMCreatePaymentProfileRequestTest extends TestCase
         $this->assertEquals($card['number'], $data->paymentProfile->payment->creditCard->cardNumber);
         $this->assertEquals('testMode', $data->validationMode);
     }
+
+    public function testGetDataOpaqueData()
+    {
+        $validCard = $this->getValidCard();
+        unset($validCard['number'],$validCard['expiryMonth'],$validCard['expiryYear'],$validCard['cvv']);
+        //remove the actual card data since we are setting opaque values
+        $this->request->initialize(
+            array(
+                'customerProfileId' => '28775801',
+                'email' => "kaylee@serenity.com",
+                'card' => $validCard,
+                'opaqueDataDescriptor' => 'COMMON.ACCEPT.INAPP.PAYMENT',
+                'opaqueDataValue' => 'jb2RlIjoiNTB',
+                'developerMode' => true
+            )
+        );
+
+        $data = $this->request->getData();
+        $this->assertEquals('COMMON.ACCEPT.INAPP.PAYMENT', $data->paymentProfile->payment->opaqueData->dataDescriptor);
+        $this->assertEquals('jb2RlIjoiNTB', $data->paymentProfile->payment->opaqueData->dataValue);
+    }
 }


### PR DESCRIPTION
- CIM CreatePaymentProfile now accepts opaque data  as well
This helps when a customer profile is already set and we just need to add the payment profile using opaque data.
- I could not find UpdatePaymentProfile method enabled so I added it and tested with opaqueData as well it should be working now.
- Also remove a test which is just a duplicate from testCreateCardSuccess.