### PR TITLE
Suppress the warning from simplexml_load_string() because we catch

### DIFF
--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -32,7 +32,7 @@ class AIMResponse extends AbstractResponse
         $xml = preg_replace('/<createTransactionResponse[^>]+>/', '<createTransactionResponse>', (string)$data);
 
         try {
-            $xml = simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING);
+            $xml = @simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING);
         } catch (\Exception $e) {
             throw new InvalidResponseException();
         }

--- a/src/Message/CIMAbstractResponse.php
+++ b/src/Message/CIMAbstractResponse.php
@@ -32,7 +32,7 @@ abstract class CIMAbstractResponse extends AbstractResponse
         $xml = preg_replace('/<' . $xmlRootElement . '[^>]+>/', '<' . $xmlRootElement . '>', (string)$data);
 
         try {
-            $xml = simplexml_load_string($xml);
+            $xml = @simplexml_load_string($xml);
         } catch (\Exception $e) {
             throw new InvalidResponseException();
         }

--- a/src/Message/Query/AIMPaymentPlanQueryResponse.php
+++ b/src/Message/Query/AIMPaymentPlanQueryResponse.php
@@ -25,7 +25,7 @@ class AIMPaymentPlanQueryResponse extends AbstractQueryResponse
         );
 
         try {
-            $xml = simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING);
+            $xml = @simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING);
         } catch (\Exception $e) {
             throw new InvalidResponseException();
         }

--- a/src/Message/Query/AIMPaymentPlansQueryResponse.php
+++ b/src/Message/Query/AIMPaymentPlansQueryResponse.php
@@ -17,7 +17,7 @@ class AIMPaymentPlansQueryResponse extends AbstractQueryResponse
         $xml = preg_replace('/<ARBGetSubscriptionListRequest[^>]+>/', '<ARBGetSubscriptionListRequest>', (string)$data);
 
         try {
-            $xml = simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING);
+            $xml = @simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING);
         } catch (\Exception $e) {
             throw new InvalidResponseException();
         }

--- a/src/Message/Query/QueryBatchDetailResponse.php
+++ b/src/Message/Query/QueryBatchDetailResponse.php
@@ -20,7 +20,7 @@ class QueryBatchDetailResponse extends AbstractQueryResponse
         );
 
         try {
-            $xml = simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING);
+            $xml = @simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING);
         } catch (\Exception $e) {
             throw new InvalidResponseException();
         }

--- a/src/Message/Query/QueryBatchResponse.php
+++ b/src/Message/Query/QueryBatchResponse.php
@@ -26,7 +26,7 @@ class QueryBatchResponse extends AbstractQueryResponse
         );
 
         try {
-            $xml = simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING);
+            $xml = @simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING);
         } catch (\Exception $e) {
             throw new InvalidResponseException();
         }

--- a/src/Message/Query/QueryDetailResponse.php
+++ b/src/Message/Query/QueryDetailResponse.php
@@ -19,7 +19,7 @@ class QueryDetailResponse extends AbstractQueryResponse
         $xml = preg_replace('/<getTransactionDetailsRequest[^>]+>/', '<getTransactionDetailsRequest>', (string)$data);
 
         try {
-            $xml = simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING);
+            $xml = @simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING);
         } catch (\Exception $e) {
             throw new InvalidResponseException();
         }


### PR DESCRIPTION
We're handling the error, so suppress the warning.