### PR TITLE
Try to get the numbers from the accountNumber in the response body

### DIFF
--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -171,7 +171,7 @@ class AIMResponse extends AbstractResponse
             try {
                 // Need to store card details in the transaction reference since it is required when doing a refund
                 if ($card = $this->request->getCard()) {
-                    if (isset($card->getNumberLastFour())) {
+                    if (null !== $card->getNumberLastFour()) {
                         $transactionRef->setCard(array(
                             'number' => $card->getNumberLastFour(),
                             'expiry' => $card->getExpiryDate('mY')

--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -171,10 +171,17 @@ class AIMResponse extends AbstractResponse
             try {
                 // Need to store card details in the transaction reference since it is required when doing a refund
                 if ($card = $this->request->getCard()) {
-                    $transactionRef->setCard(array(
-                        'number' => $card->getNumberLastFour(),
-                        'expiry' => $card->getExpiryDate('mY')
-                    ));
+                    if (isset($card->getNumberLastFour())) {
+                        $transactionRef->setCard(array(
+                            'number' => $card->getNumberLastFour(),
+                            'expiry' => $card->getExpiryDate('mY')
+                        ));
+                    } elseif (isset($body->accountNumber)) {
+                        $transactionRef->setCard(array(
+                            'number' => substr((string)$body->accountNumber, -4, 4) ?: null,
+                            'expiry' => $card->getExpiryDate('mY')
+                        ));
+                    }
                 } elseif ($cardReference = $this->request->getCardReference()) {
                     $transactionRef->setCardReference(new CardReference($cardReference));
                 }

--- a/tests/Message/AIMResponseTest.php
+++ b/tests/Message/AIMResponseTest.php
@@ -39,6 +39,40 @@ class AIMResponseTest extends TestCase
         $this->assertSame('Visa', $response->getAccountType());
     }
 
+    public function testAuthorizeCardlessSuccess()
+    {
+        $httpResponse = $this->getMockHttpResponse('AIMAuthorizeCardlessSuccess.txt');
+        $request = new AIMAuthorizeRequest($this->getHttpClient(), $this->getHttpRequest());
+        $request->initialize(
+            array(
+                'clientIp' => '10.0.0.1',
+                'amount' => '12.00',
+                'customerId' => 'cust-id',
+                'card' => array(
+                    'number' => null,
+                    'expiry' => '121999'
+                ),
+                'duplicateWindow' => 0,
+                'solutionId' => 'SOL12345ID',
+                'marketType' => '2',
+                'deviceType' => '1',
+            )
+        );
+        $request->setOpaqueDataDescriptor('COMMON.ACCEPT.INAPP.PAYMENT');
+        $request->setOpaqueDataValue('jb2RlIjoiNTB');
+        $response = new AIMResponse($request, $httpResponse->getBody());
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('{"approvalCode":"GA4OQP","transId":"2184493132","card":{"number":"1111","expiry":"121999"}}', $response->getTransactionReference());
+        $this->assertSame('This transaction has been approved.', $response->getMessage());
+        $this->assertSame(1, $response->getResultCode());
+        $this->assertSame(1, $response->getReasonCode());
+        $this->assertSame('GA4OQP', $response->getAuthorizationCode());
+        $this->assertSame('Y', $response->getAVSCode());
+        $this->assertSame('P', $response->getCVVCode());
+        $this->assertSame('Visa', $response->getAccountType());
+    }
+
     public function testAuthorizeFailure()
     {
         $httpResponse = $this->getMockHttpResponse('AIMAuthorizeFailure.txt');

--- a/tests/Mock/AIMAuthorizeCardlessSuccess.txt
+++ b/tests/Mock/AIMAuthorizeCardlessSuccess.txt
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Date: Sat, 02 Aug 2014 05:17:50 GMT
+Server: Microsoft-IIS/6.0
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: GET, POST, OPTIONS
+Access-Control-Allow-Headers: x-requested-with, cache-control, content-type, origin, method
+X-Powered-By: ASP.NET
+X-AspNet-Version: 2.0.50727
+Cache-Control: private
+Content-Type: text/xml; charset=utf-8
+Content-Length: 884
+
+<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><refId>123456</refId><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode>GA4OQP</authCode><avsResultCode>Y</avsResultCode><cvvResultCode>P</cvvResultCode><cavvResultCode>2</cavvResultCode><transId>2184493132</transId><refTransID /><transHash>DEBBE205CFD3D2DD0FD760EEBAAB81CC</transHash><testRequest>0</testRequest><accountNumber>XXXX1111</accountNumber><accountType>Visa</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages></transactionResponse></createTransactionResponse>


### PR DESCRIPTION
If last four numbers of the card aren't present in the card object (because the payment was done with opaqueData), try to get the numbers from the accountNumber in the response body.

This is so that refunds can be done for transactions without a card, like apple pay or when using Accept.js.

This is really to solve https://github.com/digital-pros/commerce-authorize/issues/15