### PR TITLE
Added functionality to query transactions and approve/deny suspicious transactions

### DIFF
--- a/src/AIMGateway.php
+++ b/src/AIMGateway.php
@@ -5,6 +5,9 @@ namespace Omnipay\AuthorizeNet;
 use Omnipay\AuthorizeNet\Message\AIMAuthorizeRequest;
 use Omnipay\AuthorizeNet\Message\AIMCaptureOnlyRequest;
 use Omnipay\AuthorizeNet\Message\AIMCaptureRequest;
+use Omnipay\AuthorizeNet\Message\AIMHeldTransactionRequest;
+use Omnipay\AuthorizeNet\Message\AIMTransactionDetailsRequest;
+use Omnipay\AuthorizeNet\Message\AIMUnsettledTransactionsRequest;
 use Omnipay\AuthorizeNet\Message\Query\AIMPaymentPlanQueryResponse;
 use Omnipay\AuthorizeNet\Message\AIMPurchaseRequest;
 use Omnipay\AuthorizeNet\Message\AIMRefundRequest;
@@ -154,6 +157,30 @@ class AIMGateway extends AbstractGateway
     {
         return $this->createRequest(
             AIMCaptureOnlyRequest::class,
+            $parameters
+        );
+    }
+
+    public function fetchTransactionDetails(array $parameters = [])
+    {
+        return $this->createRequest(
+            AIMTransactionDetailsRequest::class,
+            $parameters
+        );
+    }
+
+    public function fetchUnsettledTransactions(array $parameters = [])
+    {
+        return $this->createRequest(
+            AIMUnsettledTransactionsRequest::class,
+            $parameters
+        );
+    }
+
+    public function updateHeldTransaction(array $parameters = [])
+    {
+        return $this->createRequest(
+            AIMHeldTransactionRequest::class,
             $parameters
         );
     }

--- a/src/Message/AIMHeldTransactionRequest.php
+++ b/src/Message/AIMHeldTransactionRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Omnipay\AuthorizeNet\Message;
+
+
+class AIMHeldTransactionRequest extends AIMAbstractRequest
+{
+    protected $requestType = 'updateHeldTransactionRequest';
+
+    /**
+     * @inheritDoc
+     */
+    public function getData()
+    {
+        $data = new \SimpleXMLElement('<' . $this->requestType . '/>');
+
+        $data->addAttribute('xmlns', 'AnetApi/xml/v1/schema/AnetApiSchema.xsd');
+        $this->addAuthentication($data);
+        $this->addReferenceId($data);
+        $data->heldTransactionRequest->action = $this->getAction();
+        $data->heldTransactionRequest->refTransId = $this->getTransId();
+
+        return $data;
+    }
+
+    public function getAction()
+    {
+        return $this->getParameter('action');
+    }
+
+    public function setAction($value)
+    {
+        return $this->setParameter('action', $value);
+    }
+
+    public function getTransId()
+    {
+        return $this->getParameter('transId');
+    }
+
+    public function setTransId($value)
+    {
+        return $this->setParameter('transId', $value);
+    }
+
+}

--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -63,6 +63,11 @@ class AIMResponse extends AbstractResponse
             return intval((string)$this->data->transactionResponse->responseCode);
         }
 
+        // If there is messages, then we get the code from that.
+        if (isset($this->data->messages)) {
+            return (string)$this->data->messages->resultCode === 'Ok';
+        }
+
         // No transaction response, so return 3 aka "error".
         return static::TRANSACTION_RESULT_CODE_ERROR;
     }
@@ -164,6 +169,11 @@ class AIMResponse extends AbstractResponse
 
         if (isset($this->data->transactionResponse)) {
             $body = $this->data->transactionResponse;
+        } else if (isset($this->data->transaction)) {
+            $body = $this->data->transaction;
+        }
+
+        if (isset($body)) {
             $transactionRef = new TransactionReference();
             $transactionRef->setApprovalCode((string)$body->authCode);
             $transactionRef->setTransId((string)$body->transId);

--- a/src/Message/AIMTransactionDetailsRequest.php
+++ b/src/Message/AIMTransactionDetailsRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace Omnipay\AuthorizeNet\Message;
+
+
+class AIMTransactionDetailsRequest extends AIMAbstractRequest
+{
+    protected $requestType = 'getTransactionDetailsRequest';
+
+    /**
+     * @inheritDoc
+     */
+    public function getData()
+    {
+        $data = new \SimpleXMLElement('<' . $this->requestType . '/>');
+
+        $data->addAttribute('xmlns', 'AnetApi/xml/v1/schema/AnetApiSchema.xsd');
+        $this->addAuthentication($data);
+        $this->addReferenceId($data);
+        $data->transId = $this->getTransId();
+
+        return $data;
+    }
+
+    public function getTransId()
+    {
+        return $this->getParameter('transId');
+    }
+
+    public function setTransId($value)
+    {
+        return $this->setParameter('transId', $value);
+    }
+}

--- a/src/Message/AIMUnsettledTransactionsRequest.php
+++ b/src/Message/AIMUnsettledTransactionsRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+
+namespace Omnipay\AuthorizeNet\Message;
+
+
+use Illuminate\Support\Collection;
+
+class AIMUnsettledTransactionsRequest extends AIMAbstractRequest
+{
+    protected $requestType = 'getUnsettledTransactionListRequest';
+
+    /**
+     * @inheritDoc
+     */
+    public function getData()
+    {
+        $data = new \SimpleXMLElement('<' . $this->requestType . '/>');
+
+        $data->addAttribute('xmlns', 'AnetApi/xml/v1/schema/AnetApiSchema.xsd');
+        $this->addAuthentication($data);
+        $this->addReferenceId($data);
+        if ($this->getStatus()) {
+            $data->status = $this->getStatus();
+        }
+
+        return $data;
+    }
+
+    public function getStatus()
+    {
+        return $this->getParameter('status');
+    }
+
+    public function setStatus($value)
+    {
+        return $this->setParameter('status', $value);
+    }
+
+    public function send()
+    {
+        $response = parent::send();
+
+        if (isset($response->getData()->messages) && (string)$response->getData()->messages->resultCode === 'Ok') {
+            $transactions = new Collection();
+            foreach ((array) $response->getData()->transactions as $node) {
+                if (is_array($node)) {
+                    foreach ($node as $item) {
+                        $transactions->push(xml2array($item));
+                    }
+                } else {
+                    $transactions->push(xml2array($node));
+                }
+            }
+
+            return $transactions;
+        }
+
+        return new Collection();
+    }
+}


### PR DESCRIPTION
Authorize.net has a number of fraud filters that can leave a transaction in a "waiting for merchant review" -type status. The additional functionality added here allows merchants to query these, and subsequently send an approve or deny review to Authorize.net